### PR TITLE
feat(decomp): add Memcard functions

### DIFF
--- a/decompile/WorkInProgress/buildList.txt
+++ b/decompile/WorkInProgress/buildList.txt
@@ -1,2 +1,11 @@
 common, exe, TitleOSK_DrawMenu, 0x0, src/TitleOSK_DrawMenu_Hook.s
 common, exe, rdata_free, 0x0, src/TitleOSK_DrawMenu.c
+common, exe, MEMCARD_StringSet, 0x0, General/MEMCARD/MEMCARD_StringSet.c
+common, exe, MEMCARD_GetFreeBytes, 0x0, General/MEMCARD/MEMCARD_GetFreeBytes.c
+common, exe, MEMCARD_CloseFile, 0x0, General/MEMCARD/MEMCARD_CloseFile.c
+common, exe, MEMCARD_ReadFile, 0x0, General/MEMCARD/MEMCARD_ReadFile.c
+common, exe, MEMCARD_WriteFile, 0x0, General/MEMCARD/MEMCARD_WriteFile.c
+common, exe, MEMCARD_NewTask, 0x0, General/MEMCARD/MEMCARD_NewTask.c
+common, exe, MEMCARD_GetNextSlot1Event, 0x0, General/MEMCARD/MEMCARD_GetNextSlot1Event.c
+common, exe, MEMCARD_GetNextSlot2Event, 0x0, General/MEMCARD/MEMCARD_GetNextSlot2Event.c
+common, exe, MEMCARD_WaitForSlot1Event, 0x0, General/MEMCARD/MEMCARD_WaitForSlot1Event.c

--- a/decompile/WorkInProgress/src/MEMCARD/MEMCARD_CloseFile.c
+++ b/decompile/WorkInProgress/src/MEMCARD/MEMCARD_CloseFile.c
@@ -1,0 +1,19 @@
+#include <common.h>
+
+void MEMCARD_CloseFile(void)
+{
+    // // NOTE: this impl 4 bytes over byte budget
+    // if (sdata->memcard_fileOpen != -1)
+    // {
+    //     close(sdata->memcard_fileOpen);
+    //     sdata->memcard_fileOpen = -1;
+    // }
+    // sdata->unk_card_8008D404 = 0;
+
+    int fd = sdata->memcard_fileOpen;
+    sdata->memcard_fileOpen = -1;
+    sdata->unk_card_8008D404 = 0;
+    if (fd != -1)
+        close(fd);
+    return;
+}

--- a/decompile/WorkInProgress/src/MEMCARD/MEMCARD_GetFreeBytes.c
+++ b/decompile/WorkInProgress/src/MEMCARD/MEMCARD_GetFreeBytes.c
@@ -1,0 +1,23 @@
+#include <common.h>
+
+void MEMCARD_GetFreeBytes(int slotIdx)
+{
+  struct DIRENTRY *firstEntry;
+  struct DIRENTRY entry;
+
+  MEMCARD_StringSet(&sdata->s_bu00_BASCUS_94426_slots, slotIdx, &sdata->s_AnyFile);
+
+  int bytesUsedMemCard = 0;
+
+  // string for directory and file of save that is in use
+  firstEntry = firstfile(&sdata->s_bu00_BASCUS_94426_slots, &entry);
+
+  for (struct DIRENTRY *pDVar2 = &entry; firstEntry == pDVar2; pDVar2 = nextfile(&entry))
+  {
+    bytesUsedMemCard = bytesUsedMemCard + (entry.size + 0x1fffU & 0xffffe000);
+  }
+
+  sdata->memoryCard_SizeRemaining = 122880 - bytesUsedMemCard;
+
+  return;
+}

--- a/decompile/WorkInProgress/src/MEMCARD/MEMCARD_GetNextSlot1Event.c
+++ b/decompile/WorkInProgress/src/MEMCARD/MEMCARD_GetNextSlot1Event.c
@@ -1,0 +1,32 @@
+#include <common.h>
+
+//- basically gets index of first triggered event or returns 7, which is no event i guess. 7 is 3 bits.
+uint8_t MEMCARD_GetNextSlot1Event(void)
+{
+    uint8_t result;
+
+    // (processing done)
+    result = 0;
+    if (TestEvent(sdata->SwCARD_EvSpIOE) != 1)
+    {
+        // (bad card)
+        result = 1;
+        if (TestEvent(sdata->SwCARD_EvSpERROR) != 1)
+        {
+            // (no card)
+            if (TestEvent(sdata->SwCARD_EvSpTIMOUT) == 1)
+            {
+                result = 2;
+            }
+            else
+            {
+                result = 3;
+                if (TestEvent(sdata->SwCARD_EvSpNEW) != 1)
+                {
+                    result = 7;
+                }
+            }
+        }
+    }
+    return result;
+}

--- a/decompile/WorkInProgress/src/MEMCARD/MEMCARD_GetNextSlot2Event.c
+++ b/decompile/WorkInProgress/src/MEMCARD/MEMCARD_GetNextSlot2Event.c
@@ -1,0 +1,31 @@
+#include <common.h>
+
+uint8_t MEMCARD_GetNextSlot2Event(void)
+{
+    uint8_t result;
+
+    // (processing done)
+    result = 0;
+    if (TestEvent(sdata->HwCARD_EvSpIOE) != 1)
+    {
+        // (bad card)
+        result = 1;
+        if (TestEvent(sdata->HwCARD_EvSpERROR) != 1)
+        {
+            // (no card)
+            if (TestEvent(sdata->HwCARD_EvSpTIMOUT) == 1)
+            {
+                result = 2;
+            }
+            else
+            {
+                result = 3;
+                if (TestEvent(sdata->HwCARD_EvSpNEW) != 1)
+                {
+                    result = 7;
+                }
+            }
+        }
+    }
+    return result;
+}

--- a/decompile/WorkInProgress/src/MEMCARD/MEMCARD_NewTask.c
+++ b/decompile/WorkInProgress/src/MEMCARD/MEMCARD_NewTask.c
@@ -1,0 +1,17 @@
+#include <common.h>
+
+// param3 pointer to memcard
+// param4 memcard size
+int MEMCARD_NewTask(int slotIdx, char *name, uint8_t *param_3, int fileSize)
+{
+    sdata->memcardSlot = slotIdx;
+
+    MEMCARD_StringSet(&sdata->s_bu00_BASCUS_94426_slots, slotIdx, name);
+
+    // pointer to memcard 800992e4
+    sdata->memcard_ptrStart = param_3;
+    sdata->memcard_remainingAttempts = 8;
+    sdata->memoryCardFileSize_0x1680 = fileSize;
+
+    return 0;
+}

--- a/decompile/WorkInProgress/src/MEMCARD/MEMCARD_ReadFile.c
+++ b/decompile/WorkInProgress/src/MEMCARD/MEMCARD_ReadFile.c
@@ -1,0 +1,28 @@
+#include <common.h>
+
+int MEMCARD_ReadFile(int start_offset, int end_offset)
+
+{
+    // // NOTE: This impl is 4 bytes over byte budget
+    // // seek to start offset
+    // if (lseek(sdata->memcard_fileOpen, start_offset, 0) != -1)
+    // {
+    //     // read to memcard buffer in RAM, param_2 size
+    //     if (read(sdata->memcard_fileOpen, sdata->memcard_ptrStart, end_offset) != -1)
+    //     {
+    //         return 7;
+    //     }
+    // }
+    // MEMCARD_CloseFile();
+    // return 1;
+
+    // Bitwise AND to bail early if lseek returns invalid result
+    if ((lseek(sdata->memcard_fileOpen, start_offset, 0) != -1) &
+        (read(sdata->memcard_fileOpen, sdata->memcard_ptrStart, end_offset) != -1))
+    {
+        return 7;
+    }
+
+    MEMCARD_CloseFile();
+    return 1;
+}

--- a/decompile/WorkInProgress/src/MEMCARD/MEMCARD_StringSet.c
+++ b/decompile/WorkInProgress/src/MEMCARD/MEMCARD_StringSet.c
@@ -1,0 +1,22 @@
+#include <common.h>
+
+void MEMCARD_StringSet(char *dstString, int slotIdx, char *srcString)
+
+{
+  MEMCARD_StringInit(slotIdx, dstString);
+
+  int i = 0;
+  while (dstString[i] != '\0')
+  {
+    i++;
+  }
+
+  // copy string from src to dst
+  for (int j = 0; (srcString[j] != '\0' && i < 63); j++)
+  {
+    dstString[i] = srcString[j];
+    i++;
+  }
+  dstString[i] = '\0';
+  return;
+}

--- a/decompile/WorkInProgress/src/MEMCARD/MEMCARD_WaitForSlot1Event.c
+++ b/decompile/WorkInProgress/src/MEMCARD/MEMCARD_WaitForSlot1Event.c
@@ -1,0 +1,43 @@
+#include <common.h>
+//- only called once, wonder how that doesn't halt the exection. or maybe it does, are there hangs when save/load happens?
+uint8_t MEMCARD_WaitForSlot1Event(void)
+{
+    // // NOTE: This impl is 8 bytes over budget
+    // int result;
+    // for (;;)
+    // {
+    //     // HwIOE (processing done)
+    //     if ((result = TestEvent(sdata->HwCARD_EvSpIOE)) == 1)
+    //     {
+    //         return 0;
+    //     }
+    //     // HwERROR (bad card)
+    //     if ((result = TestEvent(sdata->HwCARD_EvSpERROR)) == 1)
+    //     {
+    //         return 1;
+    //     }
+    //     // HwTIMEOUT (no card)
+    //     if ((result = TestEvent(sdata->HwCARD_EvSpTIMOUT)) == 1)
+    //     {
+    //         return 2;
+    //     }
+    //     // HwNEWCARD
+    //     if ((result = TestEvent(sdata->HwCARD_EvSpNEW)) == 1)
+    //     {
+    //         return 3;
+    //     }
+    // }
+
+    int result;
+    do
+    {
+        result = TestEvent(sdata->HwCARD_EvSpIOE);
+        if (result) return result-1;
+        result = TestEvent(sdata->HwCARD_EvSpERROR);
+        if (result) return result;
+        result = TestEvent(sdata->HwCARD_EvSpTIMOUT);
+        if (result) return result+1;
+        result = TestEvent(sdata->HwCARD_EvSpNEW);
+    } while (!result);
+    return result+2;
+}

--- a/decompile/WorkInProgress/src/MEMCARD/MEMCARD_WriteFile.c
+++ b/decompile/WorkInProgress/src/MEMCARD/MEMCARD_WriteFile.c
@@ -1,0 +1,15 @@
+#include <common.h>
+
+uint8_t MEMCARD_WriteFile(long start_offset, void *data, long end_offset)
+
+{
+    // NOTE: See MEMCARD_ReadFile note
+    if ((lseek(sdata->memcard_fileOpen, start_offset, 0) != -1) &
+        (write(sdata->memcard_fileOpen, sdata->memcard_ptrStart, end_offset) != -1))
+    {
+        return 7;
+    }
+
+    MEMCARD_CloseFile();
+    return 1;
+}


### PR DESCRIPTION
FUN_8003d730: MEMCARD_StringSet
Byte Budget: 140/168

FUN_8003dd10: MEMCARD_GetFreeBytes
Byte Budget: 152/156

FUN_8003dbf8: MEMCARD_CloseFile
Byte Budget: 60/56

FUN_8003dc30: MEMCARD_ReadFile
Byte Budget: 108/108

FUN_8003dc9c: MEMCARD_WriteFile
Byte Budget: 108/116

FUN_8003db98: MEMCARD_NewTask
Byte Budget: 88/96

FUN_8003d9ec: MEMCARD_GetNextSlot1Event
Byte Budget: 124/124

FUN_8003da68: MEMCARD_GetNextSlot2Event
Byte Budget: 124/124

FUN_8003dae4: MEMCARD_WaitForSlot1Event
Byte Budget: 112/112