### PR TITLE
OnlineCTR: fix STATIC_ASSERT2 for GNUC

### DIFF
--- a/decompile/General/AltMods/OnlineCTR/global.h
+++ b/decompile/General/AltMods/OnlineCTR/global.h
@@ -4,10 +4,10 @@
 #endif
 
 #ifdef __GNUC__
-	#define STATIC_ASSERT2(test_for_true) \
-    extern int __static_assert[(test_for_true) ? 1 : -1] __attribute__((unused)) // GCC
+#define STATIC_ASSERT2(test_for_true, message) \
+    _Static_assert((test_for_true), message)
 #else
-	#define STATIC_ASSERT2 static_assert // Visual Studio Code
+#define STATIC_ASSERT2 static_assert // Visual Studio Code
 #endif
 
 enum ServerList


### PR DESCRIPTION
The output when there is a error looks like:
```
error: static assertion failed: "Size of SG_Header must be 1 byte"
```