### PR TITLE
Add online client support for linux

### DIFF
--- a/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
@@ -52,6 +52,12 @@ void sendToHostReliable(const void* data, size_t size) {
 	enet_peer_send(serverPeer, 0, packet); // To do: have a look at the channels, maybe we want to use them better to categorize messages
 }
 
+void system_pause() {
+	/* This is portable */
+	printf("Press any key to continue ...\n");
+	getchar();
+}
+
 void ProcessReceiveEvent(ENetPacket* packet)
 {
 	struct SG_Header* recvBuf = packet->data;
@@ -1037,7 +1043,7 @@ int main()
 	if (numDuckInstances == 0)
 	{
 		printf("Error: DuckStation is not running!\n\n");
-		system("pause");
+		system_pause();
 		exit(0);
 	}
 	else printf("Client: DuckStation detected\n");
@@ -1100,7 +1106,7 @@ int main()
 #endif
 	{
 		printf("Error: Failed to open DuckStation!\n\n");
-		getchar();
+		system_pause();
 #ifdef __WINDOWS__
 		system("cls");
 #endif
@@ -1137,7 +1143,7 @@ int main()
 	}
 
 	printf("\n");
-	system("pause");
+	system_pause();
 }
 
 #ifdef __WINDOWS__

--- a/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
@@ -10,7 +10,6 @@
 #include <fcntl.h>
 
 #define Sleep(time) sleep(time);
-#define strcpy_s(a, b, c) strncpy(a, c, b)
 
 typedef uint32_t DWORD;   // DWORD = unsigned 32 bit value
 typedef uint16_t WORD;    // WORD = unsigned 16 bit value
@@ -495,7 +494,7 @@ void StatePC_Launch_EnterIP()
 		// EUROPE
 		case 0:
 		{
-			strcpy_s(dns_string, sizeof(dns_string), "eur1.online-ctr.net");
+			strncpy(dns_string, "eur1.online-ctr.net", sizeof(dns_string));
 			enet_address_set_host(&addr, dns_string);
 			addr.port = 65001 + StaticRoomID;
 
@@ -505,7 +504,7 @@ void StatePC_Launch_EnterIP()
 		// USA
 		case 1:
 		{
-			strcpy_s(dns_string, sizeof(dns_string), "usa1.online-ctr.net");
+			strncpy(dns_string, "usa1.online-ctr.net", sizeof(dns_string));
 			enet_address_set_host(&addr, dns_string);
 			addr.port = 65001 + StaticRoomID;
 
@@ -515,7 +514,7 @@ void StatePC_Launch_EnterIP()
 		// USA WEST
 		case 2:
 		{
-			strcpy_s(dns_string, sizeof(dns_string), "usa2.online-ctr.net");
+			strncpy(dns_string, "usa2.online-ctr.net", sizeof(dns_string));
 			enet_address_set_host(&addr, dns_string);
 			addr.port = 10666 + StaticRoomID;
 
@@ -545,7 +544,7 @@ void StatePC_Launch_EnterIP()
 			ip[strcspn(ip, "\n")] = '\0';
 
 			// check if the input is empty and set it to the default IP if so
-			if (strlen(ip) == 0) strcpy_s(ip, IP_ADDRESS_SIZE, DEFAULT_IP);
+			if (strlen(ip) == 0) strncpy(ip, DEFAULT_IP, IP_ADDRESS_SIZE);
 
 		private_server_port:
 			// port number
@@ -590,7 +589,7 @@ void StatePC_Launch_EnterIP()
 		// BRAZIL
 		case 4:
 		{
-			strcpy_s(dns_string, sizeof(dns_string), "brz1.online-ctr.net");
+			strncpy(dns_string, "brz1.online-ctr.net", sizeof(dns_string));
 			enet_address_set_host(&addr, dns_string);
 			addr.port = 65001 + StaticRoomID;
 
@@ -600,7 +599,7 @@ void StatePC_Launch_EnterIP()
 		// AUSTRALIA
 		case 5:
 		{
-			strcpy_s(dns_string, sizeof(dns_string), "aus1.online-ctr.net");
+			strncpy(dns_string, "aus1.online-ctr.net", sizeof(dns_string));
 			enet_address_set_host(&addr, dns_string);
 			addr.port = 2096 + StaticRoomID;
 

--- a/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
@@ -58,6 +58,14 @@ void system_pause() {
 	getchar();
 }
 
+void system_clear() {
+#ifdef __WINDOWS__
+	system_clear();
+#elif __linux__
+	printf("\e[1;1H\e[2J");
+#endif
+}
+
 void ProcessReceiveEvent(ENetPacket* packet)
 {
 	struct SG_Header* recvBuf = packet->data;
@@ -338,7 +346,7 @@ void ProcessNewMessages()
 
 			case ENET_EVENT_TYPE_DISCONNECT:
 				// command prompt reset
-				system("cls");
+				system_clear();
 				PrintBanner(SHOW_NAME);
 				printf("\nClient: Disconnected (ENET_EVENT_TYPE_DISCONNECT)...  ");
 				Sleep(2000); // triggers a server timeout (just in case the client isn't disconnected)
@@ -393,7 +401,7 @@ void DisconSELECT()
 		StopAnimation();
 		printf("Client: Disconnected (ID: DSELECT)...  ");
 		Sleep(2000);
-		//system("cls");
+		//system_clear();
 
 		// to go the lobby browser
 		octr->CurrState = 0;
@@ -939,7 +947,7 @@ void StatePC_Game_EndRace()
 			StartAnimation();
 
 			// command prompt reset
-			system("cls");
+			system_clear();
 			PrintBanner(SHOW_NAME);
 	
 			// reset everything
@@ -992,7 +1000,7 @@ int main()
 	name[11] = 0; // truncate the name
 
 	// show a welcome message
-	system("cls");
+	system_clear();
 	PrintBanner(SHOW_NAME);
 	printf("\n");
 
@@ -1107,9 +1115,7 @@ int main()
 	{
 		printf("Error: Failed to open DuckStation!\n\n");
 		system_pause();
-#ifdef __WINDOWS__
-		system("cls");
-#endif
+		system_clear();
 		main();
 	}
 

--- a/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
@@ -6,8 +6,6 @@
 	#define _WINSOCK_DEPRECATED_NO_WARNINGS
 #endif
 
-#include <winsock2.h>
-#include <ws2tcpip.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
@@ -996,7 +996,7 @@ int main()
 
 	// ask for the users online identification
 	printf(" Enter Your Online Name: ");
-	sscanf("%s", name, (int)sizeof(name));
+	scanf("%s", name);
 	name[11] = 0; // truncate the name
 
 	// show a welcome message

--- a/mods/Windows/OnlineCTR/Network_PC/Client/CMakeLists.txt
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.20)
+project(OnlineCTR-Client C)
+
+set(CMAKE_C_STANDARD 99)
+
+# Include directories
+include_directories(${PROJECT_SOURCE_DIR}/../../../../../externals/enet/include)
+
+# Add the path to the enet library
+link_directories(${PROJECT_SOURCE_DIR}/../../../../../externals/enet/lib)
+
+# Source files
+set(SOURCES CL_main.c)
+
+# Create the executable
+add_executable(ctr_cl ${SOURCES})
+
+# Link with the enet library
+if (WIN32)
+    target_link_libraries(ctr_cl enet winmm ws2_32)
+else()
+    target_link_libraries(ctr_cl enet)
+endif()
+
+# Compiler options
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    target_compile_options(ctr_cl PRIVATE -Wno-int-conversion -Wno-incompatible-function-pointer-types -Wno-implicit-function-declaration -Wno-return-type)
+else()
+    # Assume GCC
+    target_compile_options(ctr_cl PRIVATE -Wno-implicit-function-declaration -Wno-incompatible-pointer-types)
+endif()
+
+# Debug options
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_options(ctr_cl PRIVATE -g -gdwarf-2 -O0)
+else()
+    target_compile_options(ctr_cl PRIVATE -O2)
+endif()


### PR DESCRIPTION
This won't work as is and requires a patch in duckstation to expose shared memory in Linux.
Later we will refactor the client to use PINE to access memory, instead of shmem.