### PR TITLE
Client/server: send disconnect reason when dropping a client; server ping

### DIFF
--- a/decompile/General/AltMods/OnlineCTR/global.h
+++ b/decompile/General/AltMods/OnlineCTR/global.h
@@ -118,6 +118,10 @@ enum ServerGiveMessageType
 	// connection
 	SG_NEWCLIENT,
 	SG_DROPCLIENT, // unused
+	// Disconnect reasons
+	SG_LOBBY_FULL,
+	SG_ONGOING_RACE,
+	SG_ALREADY_CONNECTED,
 
 	// lobby
 	SG_NAME,
@@ -132,6 +136,12 @@ enum ServerGiveMessageType
 	SG_SERVERCLOSED,
 
 	SG_COUNT
+};
+
+enum DisconnectReasons {
+	D_LOBBY_FULL,
+	D_ONGONG_RACE,
+	D_ALREADY_CONNECTED
 };
 
 // variety of opcodes (start load / start race)
@@ -355,8 +365,8 @@ void StatePC_Game_EndRace();
 
 // console functions
 void PrintBanner(char show_name);
-void StartAnimation();
-void StopAnimation();
+void StartSpinner();
+void StopSpinner();
 
 #endif
 

--- a/decompile/General/AltMods/OnlineCTR/global.h
+++ b/decompile/General/AltMods/OnlineCTR/global.h
@@ -1,5 +1,5 @@
 
-#define VERSION 1007
+#define VERSION 1008
 
 #ifndef WINDOWS_INCLUDE
 	#include <common.h>

--- a/mods/Windows/OnlineCTR/Network_PC/Client/Client.vcxproj.user
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/Client.vcxproj.user
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
+  <PropertyGroup>
+    <ShowAllFiles>false</ShowAllFiles>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Changes include:
- Adding disconnect reasons: Many users complained/didn't know what was happening when they joined a server and got instantly kicked. This was likely for a couple of reasons (the lobby was full, there was an ongoing race on that lobby, and so on). Sending a message to the client with a disconnect give users an explanation of why they've been disconnected from the server/room. 

- Show server ping: when connected to a server, it prints the ping every 5 seconds.

- Minor code changes/refactoring

Any suggestions or comments are welcome.
