### PR TITLE
Fix auto retry on disconnect

### DIFF
--- a/decompile/General/AltMods/OnlineCTR/global.h
+++ b/decompile/General/AltMods/OnlineCTR/global.h
@@ -400,6 +400,9 @@ void PrintBanner(char show_name);
 void StartAnimation();
 void StopAnimation();
 
+void handleDisconnect();
+void handleAutoRetry();
+
 #endif
 
 #ifndef WINDOWS_INCLUDE


### PR DESCRIPTION
The current implementation of "auto retry" is broken and doesn't do anything at all. Plus, it heavily uses goto's, [making dinosaurs appear when compiling the code](https://xkcd.com/292/).

There's also some minor changes and dead code elimination for a condition that could never happen.