### PR TITLE
Kick AFK players from character selection

### DIFF
--- a/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
@@ -375,9 +375,6 @@ void ProcessReceiveEvent(ENetPacket* packet)
 
 void ProcessNewMessages()
 {
-#define AUTO_RETRY_SECONDS 10
-#define ESC_KEY 27 // ASCII value for ESC key
-
 	ENetEvent event;
 	char response = 0;
 


### PR DESCRIPTION
Just a working proof of concept for kicking AFK players from the character selection screen. 

Timer starts ticking once any player has selected their character. Once it reaches 60 seconds, it kicks from the room all other players that have not locked in a character.