### PR TITLE
fix: endTime isn't a global variable anymore

### DIFF
--- a/mods/Windows/OnlineCTR/Network_PC/Server/SV_main.c
+++ b/mods/Windows/OnlineCTR/Network_PC/Server/SV_main.c
@@ -37,6 +37,8 @@ typedef struct
 	char boolRaceAll;
 	char boolEndAll;
 
+    int endTime;
+
 } RoomInfo;
 
 ENetHost* server;
@@ -672,7 +674,6 @@ void ServerState_FirstBoot(int argc, char** argv)
 	printf("Server: Ready on port %d\n\n", port);
 }
 
-int endTime = 0;
 void ServerState_Tick()
 {
 	ProcessNewMessages();
@@ -741,13 +742,13 @@ void ServerState_Tick()
 				printf("Terminate Race: Room=%d ", r+1);
 				PrintTime();
 				
-				endTime = clock();
+				ri->endTime = clock();
 			}
 		}
 		
 		else
 		{
-			if ( ( (clock() - endTime) / CLOCKS_PER_SEC) >= 6)
+			if ( ( (clock() - ri->endTime) / CLOCKS_PER_SEC) >= 6)
 			{
 				printf("Reset Room: Room=%d ", r+1);
 				PrintTime();
@@ -770,6 +771,7 @@ void ServerState_Tick()
 				ri->boolLoadAll = 0;
 				ri->boolRaceAll = 0;
 				ri->boolEndAll = 0;
+                ri->endTime = 0;
 			}
 		}
 	}

--- a/mods/Windows/OnlineCTR/Network_PC/Server/SV_main.c
+++ b/mods/Windows/OnlineCTR/Network_PC/Server/SV_main.c
@@ -14,6 +14,13 @@
 
 #define MAX_CLIENTS 8
 
+
+#ifdef __WINDOWS__
+#define CLOCKS_PER_SEC_FIX CLOCKS_PER_SEC
+#else
+#define CLOCKS_PER_SEC_FIX ((clock_t)100000) // Original value (1000000), I removed one zero
+#endif
+
 typedef struct {
 	ENetPeer* peer;
 
@@ -748,7 +755,7 @@ void ServerState_Tick()
 		
 		else
 		{
-			if ( ( (clock() - ri->endTime) / CLOCKS_PER_SEC) >= 6)
+			if ( ( (clock() - ri->endTime) / CLOCKS_PER_SEC_FIX) >= 6)
 			{
 				printf("Reset Room: Room=%d ", r+1);
 				PrintTime();


### PR DESCRIPTION
Besides the fact that you probably missed moving this variable in the room object while doing the server code refactor, this may fix the bug that returns you to the lobby instantly, currently testing on MEX servers.