### PR TITLE
Specify username via command line args

### DIFF
--- a/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
@@ -1013,7 +1013,7 @@ void (*ClientState[]) () = {
 // for EnumProcessModules
 #pragma comment(lib, "psapi.lib")
 
-int main()
+int main(int argc, char *argv[])
 {
 	HWND console = GetConsoleWindow();
 	RECT r;
@@ -1023,10 +1023,24 @@ int main()
 
 	PrintBanner(DONT_SHOW_NAME);
 
-	// ask for the users online identification
-	printf("Input: Enter Your Online Name: ");
-	scanf_s("%s", name, (int)sizeof(name));
-	name[11] = 0; // truncate the name
+	if (argc == 2) //1 for prog, 1 for username
+	{
+		argv[1][11] = 0; // truncate the name
+		printf("Online Name passed via args: %s", argv[1]);
+		strcpy_s(name, 12, argv[1]); // including null term
+	}
+	else if (argc == 1)
+	{
+		// ask for the users online identification
+		printf("Input: Enter Your Online Name: ");
+		scanf_s("%s", name, (int)sizeof(name));
+		name[11] = 0; // truncate the name
+	}
+	else
+	{
+		printf("Bad number of arguments passed to main(). Either pass no arguments, or just your CTROnline username");
+		exit(-1);
+	}
 
 	// show a welcome message
 	system("cls");
@@ -1115,7 +1129,7 @@ int main()
 		printf("Error: Failed to open DuckStation!\n\n");
 		system("pause");
 		system("cls");
-		main();
+		main(argc, argv);
 	}
 
 	octr = (struct OnlineCTR*)&pBuf[0x8000C000 & 0xffffff];

--- a/mods/Windows/OnlineCTR/Network_PC/start ctr online example.bat
+++ b/mods/Windows/OnlineCTR/Network_PC/start ctr online example.bat
@@ -1,0 +1,3 @@
+start "" "D:\portable_apps\GAMES\Duck Emu\duckstation-qt-x64-ReleaseLTCG.exe" -fastboot "D:\portable_apps\GAMES\Duck Emu\isos\ctr-u_Online60.bin"
+"D:\portable_apps\GAMES\ctr_online_client\Client.exe" TheUbMunster
+pause


### PR DESCRIPTION
Apologies for recreating pr, had to fix my main branch.

I found it tedious to start up duckstation and the client.exe manually (and type username), so I added the ability to specify OnlineCTR username via command line args to enable the possibility of automating the process with a simple script. In the soln directory for the Client/Server projects is an example of such a script.

The information I found regarding duckstation's args can be found [here](https://github.com/stenzek/duckstation/wiki/Command-Line-Arguments).