### PR TITLE
Online client: build using MinGW and CMake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,24 @@
               clang = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; stdenv = clangStdenv; trustCompiler = true; inherit withDebug; };
             };
           };
+          mkOnlineClient = withDebug: {
+            native32 = with pkgs32; {
+              gcc = callPackage ./mods/Windows/OnlineCTR/Network_PC/Client { ctrModSDK = self; inherit withDebug; };
+              clang = callPackage ./mods/Windows/OnlineCTR/Network_PC/Client { ctrModSDK = self; stdenv = clangStdenv; inherit withDebug; };
+            };
+            arm32 = with pkgsARM32; {
+              gcc = callPackage ./mods/Windows/OnlineCTR/Network_PC/Client { ctrModSDK = self; inherit withDebug; };
+              clang = callPackage ./mods/Windows/OnlineCTR/Network_PC/Client { ctrModSDK = self; stdenv = clangStdenv; inherit withDebug; };
+            };
+            mingw32 = with pkgsCross.mingw32; {
+              gcc = callPackage ./mods/Windows/OnlineCTR/Network_PC/Client { ctrModSDK = self; inherit withDebug; };
+              clang = callPackage ./mods/Windows/OnlineCTR/Network_PC/Client { ctrModSDK = self; stdenv = clangStdenv; trustCompiler = true; inherit withDebug; };
+            };
+            mingwW64 = with pkgsCross.mingwW64; {
+              gcc = callPackage ./mods/Windows/OnlineCTR/Network_PC/Client { ctrModSDK = self; inherit withDebug; };
+              clang = callPackage ./mods/Windows/OnlineCTR/Network_PC/Client { ctrModSDK = self; stdenv = clangStdenv; trustCompiler = true; inherit withDebug; };
+            };
+          };
         in
         rec {
           retail = {
@@ -52,6 +70,10 @@
           online-server = {
             release = mkOnline false;
             debug = mkOnline true;
+          };
+          online-client = {
+            release = mkOnlineClient false;
+            debug = mkOnlineClient true;
           };
         };
     })

--- a/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.c
@@ -12,6 +12,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <psapi.h>
+
 #pragma comment (lib, "Ws2_32.lib")
 #pragma comment (lib, "Mswsock.lib")
 #pragma comment (lib, "AdvApi32.lib")
@@ -1107,12 +1109,14 @@ int main()
 
 	// 8 MB RAM
 	const unsigned int size = 0x800000;
-	HANDLE hFile = OpenFileMapping(FILE_MAP_READ | FILE_MAP_WRITE, FALSE, duckNameT);
+	HANDLE hFile = OpenFileMappingW(FILE_MAP_READ | FILE_MAP_WRITE, FALSE, duckNameT);
+
 	pBuf = (char*)MapViewOfFile(hFile, FILE_MAP_READ | FILE_MAP_WRITE, 0, 0, size);
 
 	if (pBuf == 0)
 	{
 		printf("Error: Failed to open DuckStation!\n\n");
+		printf("\n");
 		system("pause");
 		system("cls");
 		main();

--- a/mods/Windows/OnlineCTR/Network_PC/Client/CMakeLists.txt
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.20)
+project(OnlineCTR-Client C)
+
+set(CMAKE_C_STANDARD 99)
+
+# Include directories
+include_directories(${PROJECT_SOURCE_DIR}/../../../../../externals/enet/include)
+
+# Add the path to the enet library
+link_directories(${PROJECT_SOURCE_DIR}/../../../../../externals/enet/lib)
+
+# Source files
+set(SOURCES CL_main.c)
+
+# Create the executable
+add_executable(ctr_cl ${SOURCES})
+
+# Link with the enet library
+if (WIN32)
+    target_link_libraries(ctr_cl enet winmm ws2_32 psapi wsock32 advapi32)
+else()
+    target_link_libraries(ctr_cl enet)
+endif()
+
+# Compiler options
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    target_compile_options(ctr_cl PRIVATE -Wno-int-conversion -Wno-incompatible-function-pointer-types -Wno-implicit-function-declaration -Wno-return-type)
+else()
+    # Assume GCC
+    target_compile_options(ctr_cl PRIVATE -Wno-implicit-function-declaration -Wno-incompatible-pointer-types)
+endif()
+
+# Debug options
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_options(ctr_cl PRIVATE -g -gdwarf-2 -O0)
+else()
+    target_compile_options(ctr_cl PRIVATE -O2)
+endif()

--- a/mods/Windows/OnlineCTR/Network_PC/Client/default.nix
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/default.nix
@@ -1,0 +1,77 @@
+{ lib
+, stdenv
+, cmake
+, pkg-config
+, enet
+, ctrModSDK ? ./../../../../..
+, withDebug ? true
+}:
+
+let
+  isWindows = stdenv.hostPlatform.uname.system == "Windows";
+
+  mainProgram = if isWindows then "ctr_cl.exe" else "ctr_cl";
+
+  path = "mods/Windows/OnlineCTR/Network_PC/Client";
+
+  cross-enet =
+    if isWindows then
+      enet.overrideAttrs
+        (previousAttrs: {
+          nativeBuildInputs = [ cmake ];
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p $out/lib
+            cp libenet.a $out/lib/
+
+            runHook postInstall
+          '';
+
+          meta = previousAttrs.meta // { platforms = lib.platforms.all; };
+        })
+    else enet;
+in
+stdenv.mkDerivation (_: {
+  pname = "CTR-CLIENT";
+  version = "0.0.1";
+
+  src = ctrModSDK;
+  sourceRoot =
+    if ctrModSDK == ./../../../../.. then "CTR-ModSDK/${path}"
+    else "source/${path}";
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ cross-enet ];
+
+  # Disables incompatible hardening
+  hardeningDisable = [ "format" ];
+
+  # Config
+  cmakeFlags = lib.optionals withDebug [ "-DCMAKE_BUILD_TYPE=Debug" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ${mainProgram} $out/bin/
+
+    runHook postInstall
+  '';
+
+  # Keep debug symbols
+  dontStrip = withDebug;
+
+  # Shows the proper compile date in the logs
+  env.SOURCE_DATE_EPOCH = (builtins.currentTime or ctrModSDK.lastModified);
+
+  meta = {
+    description = "CTR Online Companion";
+    homepage = "https://github.com/CTR-tools/CTR-ModSDK";
+    license = lib.licenses.publicDomain;
+    maintainers = with lib.maintainers; [ pedrohlc ];
+    mainProgram = "ctr_cl";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
This adds support to build the client using CMake and MinGW, so it can be cross-built on Linux. I re-used the nix setup that was done for the server (fun to see nix in this project!). I tested the built client, using MinGW. I don't have Windows/VisualStudio to build it on Windows.

I would like to look into porting the client to Linux and porting the memory map to PINE, but I thought it would be better if I can build and test the Windows one first, to compare and make sure I don't break things.

Most of the CMake file is from https://github.com/CTR-tools/CTR-ModSDK/pull/131

I had to do two changes to the client, one is to add `#include <psapi.h>` which seems harmless.

The second one is to change `OpenFileMapping` to `OpenFileMappingW`. This seems to be what's documented, but I'm not familiar with the Windows APIs so I'm not sure why it was needed (I assume for wide-char support) and whether it's fine for the Windows build. https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-openfilemappingw