### PR TITLE
Fix compile for CT sizeof() assertion

### DIFF
--- a/decompile/General/AltMods/OnlineCTR/global.h
+++ b/decompile/General/AltMods/OnlineCTR/global.h
@@ -223,7 +223,7 @@ struct SG_MessageClientStatus
 	unsigned char numClientsTotal : 4;
 
 	// special event
-	unsigned short special : 4;
+	unsigned char special : 4;
 };
 
 // get name from any client


### PR DESCRIPTION
fix compilation, assert sizeof(SG_MessageClientStatus) == 2 used to fail, was reporting sizeof == 4