### PR TITLE
 ci: move servers to 64; prioritize mingw32 online-server; fix GCC14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Create result directory
         run: mkdir ${{ runner.temp }}/result
-      - name: Build Server Release Linux32 GCC
-        run: nix build -L --no-link --keep-going '.?submodules=1#online-server.release.native32.gcc'
-      - name: Build Server Release ARM32 GCC
-        run: nix build -L --no-link --keep-going '.?submodules=1#online-server.release.arm32.gcc'
-      - name: Build Server Release Mingw2 GCC
+      - name: Build Server Release Linux GCC
+        run: nix build -L --no-link --keep-going '.?submodules=1#online-server.release.native.gcc'
+      - name: Build Server Release Aarch64 GCC
+        run: nix build -L --no-link --keep-going '.?submodules=1#online-server.release.aarch64.gcc'
+      - name: Build Server Release Mingw32 GCC
         run: nix build -L --keep-going '.?submodules=1#online-server.release.mingw32.gcc' -o ${{ runner.temp }}/result/online-server.release.mingw32.gcc
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,16 +22,6 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Create result directory
         run: mkdir ${{ runner.temp }}/result
-      - name: Build Decomp Debug Linux32 GCC
-        run: nix build -L --no-link --keep-going '.?submodules=1#decomp.debug.native32.gcc'
-      - name: Build Decomp Debug Linux32 Clang
-        run: nix build -L --no-link --keep-going '.?submodules=1#decomp.debug.native32.clang'
-      - name: Build Decomp Debug Mingw32 GCC
-        run: nix build -L --no-link --keep-going '.?submodules=1#decomp.debug.mingw32.gcc'
-      - name: Build Decomp Debug Mingw32 Clang
-        run: nix build -L --no-link --keep-going '.?submodules=1#decomp.debug.mingw32.clang'
-      - name: Build Retail Release Linux32 GCC
-        run: nix build -L --no-link --keep-going '.?submodules=1#retail.release.native32.gcc'
       - name: Build Server Release Linux32 GCC
         run: nix build -L --no-link --keep-going '.?submodules=1#online-server.release.native32.gcc'
       - name: Build Server Release ARM32 GCC

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Build main
 on:
   push:
     branches:
-      - '**'
+      - "**"
 
 permissions:
   contents: read
@@ -19,13 +19,8 @@ jobs:
           fetch-depth: 0
           submodules: true
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Create result directory
         run: mkdir ${{ runner.temp }}/result
-      - name: Build Server Release Linux GCC
-        run: nix build -L --no-link --keep-going '.?submodules=1#online-server.release.native.gcc'
-      - name: Build Server Release Aarch64 GCC
-        run: nix build -L --no-link --keep-going '.?submodules=1#online-server.release.aarch64.gcc'
       - name: Build Server Release Mingw32 GCC
         run: nix build -L --keep-going '.?submodules=1#online-server.release.mingw32.gcc' -o ${{ runner.temp }}/result/online-server.release.mingw32.gcc
       - name: Upload artifact
@@ -34,3 +29,7 @@ jobs:
           name: online-server-windows
           path: |
             ${{ runner.temp }}/result/online-server.release.mingw32.gcc/bin
+      - name: Build Server Release Linux GCC
+        run: nix build -L --no-link --keep-going '.?submodules=1#online-server.release.native.gcc'
+      - name: Build Server Release Aarch64 GCC
+        run: nix build -L --no-link --keep-going '.?submodules=1#online-server.release.aarch64.gcc'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - name: Create result directory
         run: mkdir ${{ runner.temp }}/result
+      # -- Windows online-server
       - name: Build Server Release Mingw32 GCC
         run: nix build -L --keep-going '.?submodules=1#online-server.release.mingw32.gcc' -o ${{ runner.temp }}/result/online-server.release.mingw32.gcc
       - name: Upload artifact
@@ -28,8 +29,15 @@ jobs:
         with:
           name: online-server-windows
           path: |
-            ${{ runner.temp }}/result/online-server.release.mingw32.gcc/bin
+            ${{ runner.temp }}/result/online-server.release.mingw32.gcc/
+
+      # -- Linux online-server
       - name: Build Server Release Linux GCC
         run: nix build -L --no-link --keep-going '.?submodules=1#online-server.release.native.gcc'
       - name: Build Server Release Aarch64 GCC
         run: nix build -L --no-link --keep-going '.?submodules=1#online-server.release.aarch64.gcc'
+      # -- PC Port
+      - name: Build Decomp Debug Mingw32 GCC
+        run: nix build -L --no-link --keep-going '.?submodules=1#pc-decomp.debug.mingw32.gcc' 2>&1 | grep -A3 'error:'
+      - name: Build Decomp Debug Linux32 GCC
+        run: nix build -L --no-link --keep-going '.?submodules=1#pc-decomp.debug.native32.gcc' 2>&1 | grep -A3 'error:'

--- a/flake.lock
+++ b/flake.lock
@@ -15,12 +15,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727634051,
-        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
-        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
-        "revCount": 687049,
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
+        "revCount": 755230,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.687049%2Brev-06cf0e1da4208d3766d898b7fdab6513366d45b9/019243b7-0a9f-79f7-b57a-4e0cfd13a578/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.755230%2Brev-73cf49b8ad837ade2de76f87eb53fc85ed5d4680/01951ca9-35fa-70f2-b972-630b0cd93c65/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.lock
+++ b/flake.lock
@@ -15,12 +15,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715787315,
-        "narHash": "sha256-cYApT0NXJfqBkKcci7D9Kr4CBYZKOQKDYA23q8XNuWg=",
-        "rev": "33d1e753c82ffc557b4a585c77de43d4c922ebb5",
-        "revCount": 626834,
+        "lastModified": 1727634051,
+        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
+        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
+        "revCount": 687049,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.626834%2Brev-33d1e753c82ffc557b4a585c77de43d4c922ebb5/018f8037-433d-77f3-b4bb-e542e48f7fd6/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.687049%2Brev-06cf0e1da4208d3766d898b7fdab6513366d45b9/019243b7-0a9f-79f7-b57a-4e0cfd13a578/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
     (_: { pkgs, system }: with pkgs; rec {
       packages =
         let
+          pkgsAarch64 = pkgsCross.aarch64-multiplatform;
           pkgsARM32 = pkgsCross.armv7l-hf-multiplatform;
           pkgs32 = if system == "x86_64-linux" then pkgsi686Linux else pkgsARM32;
 
@@ -26,13 +27,25 @@
           };
 
           mkOnline = withDebug: {
+            native = {
+              gcc = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; inherit withDebug; };
+              clang = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; stdenv = clangStdenv; inherit withDebug; };
+            };
             native32 = with pkgs32; {
+              gcc = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; inherit withDebug; };
+              clang = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; stdenv = clangStdenv; inherit withDebug; };
+            };
+            aarch64 = with pkgsAarch64; {
               gcc = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; inherit withDebug; };
               clang = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; stdenv = clangStdenv; inherit withDebug; };
             };
             arm32 = with pkgsARM32; {
               gcc = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; inherit withDebug; };
               clang = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; stdenv = clangStdenv; inherit withDebug; };
+            };
+            mingwW64 = with pkgsCross.mingwW64; {
+              gcc = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; inherit withDebug; };
+              clang = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; stdenv = clangStdenv; trustCompiler = true; inherit withDebug; };
             };
             mingw32 = with pkgsCross.mingw32; {
               gcc = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; inherit withDebug; };

--- a/flake.nix
+++ b/flake.nix
@@ -54,11 +54,11 @@
           };
         in
         rec {
-          retail = {
+          pc-retail = {
             release = mkCTR false false;
             debug = mkCTR true false;
           };
-          decomp = {
+          pc-decomp = {
             release = mkCTR false true;
             debug = mkCTR true true;
           };

--- a/mods/Windows/OnlineCTR/Network_PC/Server/CMakeLists.txt
+++ b/mods/Windows/OnlineCTR/Network_PC/Server/CMakeLists.txt
@@ -27,7 +27,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     target_compile_options(ctr_srv PRIVATE -Wno-int-conversion -Wno-incompatible-function-pointer-types -Wno-implicit-function-declaration -Wno-return-type)
 else()
     # Assume GCC
-    target_compile_options(ctr_srv PRIVATE -Wno-implicit-function-declaration -Wno-incompatible-pointer-types)
+    target_compile_options(ctr_srv PRIVATE -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-implicit-int)
 endif()
 
 # Debug options

--- a/rebuild_PC/CMakeLists.txt
+++ b/rebuild_PC/CMakeLists.txt
@@ -84,7 +84,7 @@ if(CTR_VR)
   target_compile_options(ctr_bin PUBLIC -DUSE_VR)
 endif()
 
-# Clang is rigorous
+# Compiler options
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
   target_compile_options(ctr_bin PUBLIC -Wno-int-conversion -Wno-incompatible-function-pointer-types -Wno-implicit-function-declaration -Wno-return-type)
   if(MINGW OR CYGWIN)
@@ -92,6 +92,9 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
       target_link_options(ctr_bin PUBLIC -static-libgcc)
     endif()
   endif()
+else()
+  # Assume GCC
+  target_compile_options(ctr_bin PRIVATE -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-implicit-int)
 endif()
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
@@ -141,7 +144,7 @@ add_library(psycross_static STATIC ${PSYCROSS_SRCS_C} ${PSYCROSS_SRCS_CPP})
 set_target_properties(psycross_static PROPERTIES OUTPUT_NAME "psycross")
 target_include_directories(psycross_static PUBLIC "../externals/PsyCross/include")
 
-target_compile_options(psycross_static PRIVATE -Wno-narrowing)
+target_compile_options(psycross_static PRIVATE -Wno-narrowing -Wno-incompatible-pointer-types -Wno-implicit-function-declaration)
 
 target_link_libraries(psycross_static ${SDL2_LIBRARIES})
 target_include_directories(psycross_static PRIVATE ${SDL2_INCLUDE_DIRS})


### PR DESCRIPTION
Includes #195 

It looks like everybody is using 64-bit variants of online-server on Linux. On Windows, it doesn't really make that much difference, since you have the right dependencies bundled with the system.