### PR TITLE
OnlineCTR Server ServerState_FirstBoot function type fix

### DIFF
--- a/mods/Windows/OnlineCTR/Network_PC/Server/SV_main.c
+++ b/mods/Windows/OnlineCTR/Network_PC/Server/SV_main.c
@@ -619,7 +619,7 @@ void ProcessNewMessages() {
 	}
 }
 
-void ServerState_FirstBoot(int argc, char** argv)
+int ServerState_FirstBoot(int argc, char** argv)
 {
 	printf(__DATE__);
 	printf("\n");


### PR DESCRIPTION
For some reason ServerState_FirstBoot function is void, while it's trying to return integer. Because of this Server can't be built. I just changed the function type to int.