### PR TITLE
ci: move to UCRT64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,14 +22,14 @@ jobs:
       - name: Create result directory
         run: mkdir ${{ runner.temp }}/result
       # -- Windows online-server
-      - name: Build Server Release Mingw32 GCC
-        run: nix build -L --keep-going '.?submodules=1#online-server.release.mingw32.gcc' -o ${{ runner.temp }}/result/online-server.release.mingw32.gcc
+      - name: Build Server Release UCRT64 GCC
+        run: nix build -L --keep-going '.?submodules=1#online-server.release.ucrt64.gcc' -o ${{ runner.temp }}/result/online-server.release.ucrt64.gcc
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: online-server-windows
           path: |
-            ${{ runner.temp }}/result/online-server.release.mingw32.gcc/
+            ${{ runner.temp }}/result/online-server.release.ucrt64.gcc/
 
       # -- Linux online-server
       - name: Build Server Release Linux GCC

--- a/flake.lock
+++ b/flake.lock
@@ -15,12 +15,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
-        "revCount": 782401,
+        "lastModified": 1754214453,
+        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
+        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
+        "revCount": 838708,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.782401%2Brev-2631b0b7abcea6e640ce31cd78ea58910d31e650/01962c8a-63c4-7abd-a3df-63a17b548cc7/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.838708%2Brev-5b09dc45f24cf32316283e62aec81ffee3c3e376/0198762e-0143-77ff-9b8e-5845fdbe02c7/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,10 @@
               gcc = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; inherit withDebug; };
               clang = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; stdenv = clangStdenv; trustCompiler = true; inherit withDebug; };
             };
+            ucrt64 = with pkgsCross.ucrt64; {
+              gcc = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; inherit withDebug; };
+              clang = callPackage ./mods/Windows/OnlineCTR/Network_PC/Server { ctrModSDK = self; stdenv = clangStdenv; trustCompiler = true; inherit withDebug; };
+            };
           };
         in
         rec {

--- a/mods/Windows/OnlineCTR/Network_PC/Server/CMakeLists.txt
+++ b/mods/Windows/OnlineCTR/Network_PC/Server/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 # Compiler options
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-    target_compile_options(ctr_srv PRIVATE -Wno-int-conversion -Wno-incompatible-function-pointer-types -Wno-implicit-function-declaration -Wno-return-type)
+    target_compile_options(ctr_srv PRIVATE -Wno-int-conversion -Wno-incompatible-function-pointer-types -Wno-implicit-function-declaration -Wno-return-type -Wno-implicit-int)
 else()
     # Assume GCC
     target_compile_options(ctr_srv PRIVATE -Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-implicit-int)

--- a/mods/Windows/OnlineCTR/Network_PC/Server/default.nix
+++ b/mods/Windows/OnlineCTR/Network_PC/Server/default.nix
@@ -5,6 +5,7 @@
 , enet
 , ctrModSDK ? ./../../../../..
 , withDebug ? true
+, trustCompiler ? false
 }:
 
 let
@@ -20,13 +21,11 @@ let
         (previousAttrs: {
           nativeBuildInputs = [ cmake ];
 
-          installPhase = ''
-            runHook preInstall
+          outputs = [ "out" "dev" ];
 
-            mkdir -p $out/lib
-            cp libenet.a $out/lib/
-
-            runHook postInstall
+          postInstall = ''
+            mkdir -p $dev/lib
+            cp libenet.a $dev/lib/
           '';
 
           meta = previousAttrs.meta // { platforms = lib.platforms.all; };
@@ -49,7 +48,8 @@ stdenv.mkDerivation (_: {
   hardeningDisable = [ "format" ];
 
   # Config
-  cmakeFlags = lib.optionals withDebug [ "-DCMAKE_BUILD_TYPE=Debug" ];
+  cmakeFlags = lib.optionals withDebug [ "-DCMAKE_BUILD_TYPE=Debug" ]
+    ++ lib.optionals trustCompiler [ "-DCMAKE_C_COMPILER_WORKS=1" "-DCMAKE_CXX_COMPILER_WORKS=1" ];
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
This is the newer C runtime for MinGW. And if I understood it right, this means Windows users can use these binaries without the DLLs from MinGW.

Before merging, get a Windows user to test, getting the `ctr_srv.exe` from: https://github.com/PedroHLC/CTR-ModSDK/actions/runs/16752646009/artifacts/3691740371. And run it like they already would.