### PR TITLE
OnlineCTR: Add Europe server

### DIFF
--- a/decompile/General/AltMods/OnlineCTR/menu.c
+++ b/decompile/General/AltMods/OnlineCTR/menu.c
@@ -99,12 +99,8 @@ void NewPage_ServerCountry()
 		menuRows[i].stringIndex |= 0x8000;
 	#else
 	//disable beta
-	i = 6;
-	menuRows[i].stringIndex |= 0x8000;
+	menuRows[6].stringIndex |= 0x8000;
 	#endif
-	//disable europe for the time being
-	i = 0;
-	menuRows[i].stringIndex |= 0x8000;
 }
 
 void MenuWrites_ServerCountry()

--- a/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.cpp
+++ b/mods/Windows/OnlineCTR/Network_PC/Client/CL_main.cpp
@@ -584,10 +584,10 @@ void StatePC_Launch_PickServer()
 
 	switch (octr->serverCountry)
 	{
-		// EUROPE (Unknown Location)
+		// EUROPE (Gravelines)
 		case 0:
 		{
-			strcpy_s(dns_string, sizeof(dns_string), "eur1.online-ctr.net");
+			strcpy_s(dns_string, sizeof(dns_string), "octr.bemug.fr");
 			enet_address_set_host(&addr, dns_string);
 			addr.port = 64001;
 


### PR DESCRIPTION
I took time to host a server in Gravelines, France.

The first commit enables back the Europe server selection in the OnlineCTR client.

The second commit makes the client point to the server's name. I advice **against** merging it, and modifying the DNS entry for `eur1.online-ctr.net` instead. But that works as is.

As I'm running Linux I can't build nor test. I'd like someone to test it prior to merging. This PR is pretty straightforward but you never know.