### PR TITLE
fix(decomp): token race flag not cleared properly

### DIFF
--- a/decompile/General/222/222_Full.c
+++ b/decompile/General/222/222_Full.c
@@ -415,7 +415,8 @@ void DECOMP_AA_EndEvent_DrawMenu(void)
 	RECTMENU_ClearInput();
 	
 	sdata->Loading.OnBegin.AddBitsConfig0 |= ADVENTURE_ARENA;
-	sdata->Loading.OnBegin.RemBitsConfig0 |= (ADVENTURE_BOSS | TOKEN_RACE);
+	sdata->Loading.OnBegin.RemBitsConfig0 |= ADVENTURE_BOSS;
+	sdata->Loading.OnBegin.RemBitsConfig8 |= TOKEN_RACE;
 
 	// If you are in boss mode
 	if (gGT->gameMode1 < 0)


### PR DESCRIPTION
Decomp:  

The end of a regular adventure race is supposed to remove the `TOKEN_RACE` flag from `gGT->gameMode2`.
However, due to an oversight, `TOKEN_RACE` is marked to be removed via `sdata->Loading.OnBegin.RemBitsConfig0`, which is used for `gGT->gameMode1`, the wrong gamemode field.  
  
Due to this, finishing a CTR Token Challenge in Adventure Mode does not clear the token race flag. If you finish a CTR Token Challenge, then enter a track where you have not beaten the trophy race yet, then you will be thrown into the CTR Token Challenge right away.  

This PR addresses this by assigning the `TOKEN_RACE` value to the correct `RemBitsConfig` field.